### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Here we'll walk through the `amplify configure` setup. Once you've signed in to 
 amplify init
 ```
 
-- Enter a name for the project: __amplify-app__
+- Enter a name for the project: __amplifyapp__
 - Enter a name for the environment: __dev__
 - Choose your default editor: __Visual Studio Code__   
 - Please choose the type of app that you're building __javascript__   


### PR DESCRIPTION
entering amplify-amp as the name of the project causes the following error:

"Project name should be between 3 and 20 characters and alphanumeric"

Removing the hyphen so the name becomes "amplifyapp" fixes this problem.